### PR TITLE
feat: display fundraise position details

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -97,6 +97,81 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "FundraisePosition",
+        "description": null,
+        "fields": [
+          {
+            "name": "contribution",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reward",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stake",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "SCALAR",
         "name": "GUID",
         "description": null,
@@ -522,6 +597,35 @@
         "name": "Query",
         "description": null,
         "fields": [
+          {
+            "name": "fundraisePosition",
+            "description": null,
+            "args": [
+              {
+                "name": "owner",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "FundraisePosition",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "positions",
             "description": null,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -102,6 +102,22 @@
         "description": null,
         "fields": [
           {
+            "name": "claimableAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "contribution",
             "description": null,
             "args": [],

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -118,6 +118,22 @@
             "deprecationReason": null
           },
           {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "owner",
             "description": null,
             "args": [],
@@ -225,6 +241,16 @@
         "kind": "SCALAR",
         "name": "IBAN",
         "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "ID",
+        "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,

--- a/src/graphql/queries/GetFundraisePosition.graphql
+++ b/src/graphql/queries/GetFundraisePosition.graphql
@@ -4,5 +4,6 @@ query GetFundraisePosition($owner: String!) {
     stake
     contribution
     reward
+    claimableAt
   }
 }

--- a/src/graphql/queries/GetFundraisePosition.graphql
+++ b/src/graphql/queries/GetFundraisePosition.graphql
@@ -1,0 +1,8 @@
+query GetFundraisePosition($owner: String!) {
+  fundraisePosition(owner: $owner) {
+    owner
+    stake
+    contribution
+    reward
+  }
+}

--- a/src/graphql/types.tsx
+++ b/src/graphql/types.tsx
@@ -68,6 +68,14 @@ export type Scalars = {
   Void: any
 }
 
+export type FundraisePosition = {
+  __typename?: "FundraisePosition"
+  contribution: Scalars["BigInt"]
+  owner: Scalars["String"]
+  reward: Scalars["BigInt"]
+  stake: Scalars["BigInt"]
+}
+
 export type Position = {
   __typename?: "Position"
   expiration: Scalars["BigInt"]
@@ -79,11 +87,31 @@ export type Position = {
 
 export type Query = {
   __typename?: "Query"
+  fundraisePosition?: Maybe<FundraisePosition>
   positions?: Maybe<Array<Maybe<Position>>>
+}
+
+export type QueryFundraisePositionArgs = {
+  owner: Scalars["String"]
 }
 
 export type QueryPositionsArgs = {
   owner: Scalars["String"]
+}
+
+export type GetFundraisePositionQueryVariables = Exact<{
+  owner: Scalars["String"]
+}>
+
+export type GetFundraisePositionQuery = {
+  __typename?: "Query"
+  fundraisePosition?: {
+    __typename?: "FundraisePosition"
+    owner: string
+    stake: BigInt
+    contribution: BigInt
+    reward: BigInt
+  } | null
 }
 
 export type GetPositionsQueryVariables = Exact<{
@@ -102,6 +130,57 @@ export type GetPositionsQuery = {
   } | null> | null
 }
 
+export const GetFundraisePositionDocument = gql`
+  query GetFundraisePosition($owner: String!) {
+    fundraisePosition(owner: $owner) {
+      owner
+      stake
+      contribution
+      reward
+    }
+  }
+`
+
+/**
+ * __useGetFundraisePositionQuery__
+ *
+ * To run a query within a React component, call `useGetFundraisePositionQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetFundraisePositionQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetFundraisePositionQuery({
+ *   variables: {
+ *      owner: // value for 'owner'
+ *   },
+ * });
+ */
+export function useGetFundraisePositionQuery(
+  baseOptions: Apollo.QueryHookOptions<GetFundraisePositionQuery, GetFundraisePositionQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<GetFundraisePositionQuery, GetFundraisePositionQueryVariables>(
+    GetFundraisePositionDocument,
+    options
+  )
+}
+export function useGetFundraisePositionLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<GetFundraisePositionQuery, GetFundraisePositionQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<GetFundraisePositionQuery, GetFundraisePositionQueryVariables>(
+    GetFundraisePositionDocument,
+    options
+  )
+}
+export type GetFundraisePositionQueryHookResult = ReturnType<typeof useGetFundraisePositionQuery>
+export type GetFundraisePositionLazyQueryHookResult = ReturnType<typeof useGetFundraisePositionLazyQuery>
+export type GetFundraisePositionQueryResult = Apollo.QueryResult<
+  GetFundraisePositionQuery,
+  GetFundraisePositionQueryVariables
+>
 export const GetPositionsDocument = gql`
   query GetPositions($owner: String!) {
     positions(owner: $owner) {

--- a/src/graphql/types.tsx
+++ b/src/graphql/types.tsx
@@ -70,6 +70,7 @@ export type Scalars = {
 
 export type FundraisePosition = {
   __typename?: "FundraisePosition"
+  claimableAt: Scalars["BigInt"]
   contribution: Scalars["BigInt"]
   id: Scalars["ID"]
   owner: Scalars["String"]
@@ -112,6 +113,7 @@ export type GetFundraisePositionQuery = {
     stake: BigInt
     contribution: BigInt
     reward: BigInt
+    claimableAt: BigInt
   } | null
 }
 
@@ -138,6 +140,7 @@ export const GetFundraisePositionDocument = gql`
       stake
       contribution
       reward
+      claimableAt
     }
   }
 `

--- a/src/graphql/types.tsx
+++ b/src/graphql/types.tsx
@@ -71,6 +71,7 @@ export type Scalars = {
 export type FundraisePosition = {
   __typename?: "FundraisePosition"
   contribution: Scalars["BigInt"]
+  id: Scalars["ID"]
   owner: Scalars["String"]
   reward: Scalars["BigInt"]
   stake: Scalars["BigInt"]

--- a/src/pages/FundraisingClaim/FundraisingClaim.tsx
+++ b/src/pages/FundraisingClaim/FundraisingClaim.tsx
@@ -59,14 +59,26 @@ export const FundraisingClaimPage = () => {
     }
   }, [sherClaim, refetchFundraisePosition])
 
+  if (!fundraisePositionData?.fundraisePosition) return null
+
   const sherAmount =
     fundraisePositionData?.fundraisePosition?.reward && BigNumber.from(fundraisePositionData.fundraisePosition.reward)
-  const formattedSherAmount = sherAmount && ethers.utils.formatUnits(sherAmount)
+  const formattedSherAmount = ethers.utils.commify(ethers.utils.formatUnits(sherAmount))
+
+  const claimableAt = new Date(Number(fundraisePositionData.fundraisePosition.claimableAt))
+
+  const stake = BigNumber.from(fundraisePositionData.fundraisePosition.stake)
+  const contribution = BigNumber.from(fundraisePositionData.fundraisePosition.contribution)
+  const participation = stake.add(contribution)
 
   return (
     <div>
       <h1>CLAIM</h1>
-      {formattedSherAmount && <h2>Available for claim: {formattedSherAmount} SHER</h2>}
+      <h2>Participation: {ethers.utils.commify(ethers.utils.formatUnits(participation, 6))}</h2>
+      <h2>Stake: {ethers.utils.commify(ethers.utils.formatUnits(stake, 6))}</h2>
+      <h2>Contributed: {ethers.utils.commify(ethers.utils.formatUnits(contribution, 6))}</h2>
+      <h2>Reward: {formattedSherAmount} SHER</h2>
+      <h2>Claimable starts: {claimableAt.toDateString()}</h2>
       <button onClick={handleClaim} disabled={!claimIsActive}>
         {claimIsActive ? `Claim ${formattedSherAmount} SHER` : "Claim is not active yet"}
       </button>

--- a/src/pages/FundraisingClaim/FundraisingClaim.tsx
+++ b/src/pages/FundraisingClaim/FundraisingClaim.tsx
@@ -11,7 +11,7 @@ export const FundraisingClaimPage = () => {
   /**
    * GraphQL query to fetch fundraise position
    */
-  const [getFundraisePotision, { data: fundraisePositionData, refetch: refetchFundraisePosition }] =
+  const [getFundraisePosition, { data: fundraisePositionData, refetch: refetchFundraisePosition }] =
     useGetFundraisePositionLazyQuery()
 
   /**
@@ -24,13 +24,13 @@ export const FundraisingClaimPage = () => {
    */
   useEffect(() => {
     if (accountData?.address) {
-      getFundraisePotision({
+      getFundraisePosition({
         variables: {
           owner: accountData.address,
         },
       })
     }
-  }, [accountData?.address, getFundraisePotision])
+  }, [accountData?.address, getFundraisePosition])
 
   /**
    * Fetch claim is active or not from smart contract

--- a/src/utils/apollo/ApolloProvider.tsx
+++ b/src/utils/apollo/ApolloProvider.tsx
@@ -42,7 +42,6 @@ const positions = [
     id: 2,
     owner: "0x0B6a04b8D3d050cbeD9A4621A5D503F27743c942",
     usdcAmount: BigNumber.from("1000000").toBigInt(),
-    sherAmount: BigNumber.from("1000000000000000000").toBigInt(),
     expiration: BigNumber.from(1644249926818).toBigInt(),
   },
   {
@@ -54,10 +53,28 @@ const positions = [
   },
 ]
 
+const fundraisePositions = [
+  {
+    id: "0x100F04C9B98AB9D22772Aacc469bEA466d54cc4A",
+    owner: "0x100F04C9B98AB9D22772Aacc469bEA466d54cc4A",
+    stake: BigNumber.from("90000000000").toBigInt(),
+    contribution: BigNumber.from("10000000000").toBigInt(),
+    reward: BigNumber.from("10000000000000000000000").toBigInt(),
+  },
+  {
+    id: "0x0B6a04b8D3d050cbeD9A4621A5D503F27743c942",
+    owner: "0x0B6a04b8D3d050cbeD9A4621A5D503F27743c942",
+    stake: BigNumber.from("90000000000").toBigInt(),
+    contribution: BigNumber.from("10000000000").toBigInt(),
+    reward: BigNumber.from("10000000000000000000000").toBigInt(),
+  },
+]
+
 const resolvers = {
   ...scalarResolvers,
   Query: {
     positions: (_ctx: any, { owner }: { owner: string }) => positions.filter((p) => p.owner === owner),
+    fundraisePosition: (_ctx: any, { owner }: { owner: string }) => fundraisePositions.find((p) => p.owner === owner),
   },
 }
 

--- a/src/utils/apollo/ApolloProvider.tsx
+++ b/src/utils/apollo/ApolloProvider.tsx
@@ -60,6 +60,7 @@ const fundraisePositions = [
     stake: BigNumber.from("90000000000").toBigInt(),
     contribution: BigNumber.from("10000000000").toBigInt(),
     reward: BigNumber.from("10000000000000000000000").toBigInt(),
+    claimableAt: BigNumber.from(1644344664090 + 60 * 60 * 24 * 10).toBigInt(),
   },
   {
     id: "0x0B6a04b8D3d050cbeD9A4621A5D503F27743c942",
@@ -67,6 +68,7 @@ const fundraisePositions = [
     stake: BigNumber.from("90000000000").toBigInt(),
     contribution: BigNumber.from("10000000000").toBigInt(),
     reward: BigNumber.from("10000000000000000000000").toBigInt(),
+    claimableAt: BigNumber.from(1644344664090 + 60 * 60 * 24 * 10).toBigInt(),
   },
 ]
 

--- a/src/utils/apollo/schema.graphql
+++ b/src/utils/apollo/schema.graphql
@@ -7,6 +7,7 @@ type Position {
 }
 
 type FundraisePosition {
+  id: ID!
   owner: String! # owner's address
   stake: BigInt! # in USDC
   contribution: BigInt! # in USDC

--- a/src/utils/apollo/schema.graphql
+++ b/src/utils/apollo/schema.graphql
@@ -6,6 +6,14 @@ type Position {
   owner: String! # owner's address
 }
 
+type FundraisePosition {
+  owner: String! # owner's address
+  stake: BigInt! # in USDC
+  contribution: BigInt! # in USDC
+  reward: BigInt! # in SHER
+}
+
 type Query {
   positions(owner: String!): [Position]
+  fundraisePosition(owner: String!): FundraisePosition
 }

--- a/src/utils/apollo/schema.graphql
+++ b/src/utils/apollo/schema.graphql
@@ -12,6 +12,7 @@ type FundraisePosition {
   stake: BigInt! # in USDC
   contribution: BigInt! # in USDC
   reward: BigInt! # in SHER
+  claimableAt: BigInt! # timestamp
 }
 
 type Query {


### PR DESCRIPTION
Consume GraphQL endpoint and display details such as:
- Participation total
- Stake
- Contribution
- SHER rewards
- Claim start date

