### PR TITLE
fix: hide capital requirements when input is 0

### DIFF
--- a/src/pages/Fundraising/Fundraising.tsx
+++ b/src/pages/Fundraising/Fundraising.tsx
@@ -127,7 +127,10 @@ export const FundraisingPage: React.FC = () => {
    */
   useEffect(() => {
     const calculateRewards = async () => {
-      if (!debouncedUsdcInput || !usdcToSherRewardRatio) return
+      if (!debouncedUsdcInput || !usdcToSherRewardRatio || debouncedUsdcInput.isZero()) {
+        setRewards(undefined)
+        return
+      }
 
       setIsLoadingRewards(true)
 
@@ -152,7 +155,9 @@ export const FundraisingPage: React.FC = () => {
   }, [debouncedUsdcInput, setIsLoadingRewards, usdcToSherRewardRatio, setRewards, sherBuyContract])
 
   const handleUsdcChange = (value: BigNumber | undefined) => {
-    if (!value) return
+    if (!value) {
+      setRewards(undefined)
+    }
 
     setUsdcInput(value)
   }


### PR DESCRIPTION
Capital requirements section was displaying the last results before the user erased the input entirely.

This PR hides the capital requirements section as soon as the input turns 0. This way we avoid displaying otudated data.