### PR TITLE
Feat/fundraise button disabled state

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,8 +2,16 @@ import React from "react"
 import cx from "classnames"
 
 import styles from "./Button.module.scss"
+import { BigNumber } from "ethers"
+import ConnectGate from "../ConnectGate/ConnectGate"
+import AllowanceGate from "../AllowanceGate/AllowanceGate"
 
 type ButtonVariant = "primary" | "secondary" | "alternate" | "cta"
+
+type Allowance = {
+  spender: string
+  amount: BigNumber
+}
 
 export type ButtonProps = {
   /**
@@ -20,12 +28,48 @@ export type ButtonProps = {
    * Button variant (@see ButtonVariant)
    */
   variant?: ButtonVariant
+
+  /**
+   * Wether the action requires to have a connected account or not.
+   * `ConnectGate` HOC will be used.
+   */
+  requiresConnected?: boolean
+
+  /**
+   * Wether the action requires certain allowance.
+   * `AllowanceGate` HOC will be used.
+   */
+  allowance?: Allowance
 }
 
-export const Button: React.FC<ButtonProps> = ({ children, onClick, disabled, variant = "primary" }) => {
-  return (
+export const Button: React.FC<ButtonProps> = ({
+  children,
+  onClick,
+  disabled,
+  variant = "primary",
+  requiresConnected = false,
+  allowance,
+}) => {
+  const ConnectGateOrEmptyFragment = requiresConnected ? ConnectGate : React.Fragment
+  const AllowanceGateOrEmptyFragment: React.FC = allowance
+    ? (children) => (
+        <AllowanceGate spender={allowance.spender} amount={allowance.amount}>
+          {children}
+        </AllowanceGate>
+      )
+    : React.Fragment
+
+  const button = (
     <button className={cx(styles.button, styles[variant])} onClick={onClick} disabled={disabled}>
       <div className={styles.content}>{children}</div>
     </button>
+  )
+
+  return disabled ? (
+    button
+  ) : (
+    <ConnectGateOrEmptyFragment>
+      <AllowanceGateOrEmptyFragment>{button}</AllowanceGateOrEmptyFragment>
+    </ConnectGateOrEmptyFragment>
   )
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -42,6 +42,15 @@ export type ButtonProps = {
   allowance?: Allowance
 }
 
+const AllowanceGateOrEmptyFragment: React.FC<{ allowance?: Allowance }> = ({ allowance, children }) =>
+  allowance ? (
+    <AllowanceGate spender={allowance.spender} amount={allowance.amount}>
+      {children}
+    </AllowanceGate>
+  ) : (
+    <>{children}</>
+  )
+
 export const Button: React.FC<ButtonProps> = ({
   children,
   onClick,
@@ -51,13 +60,6 @@ export const Button: React.FC<ButtonProps> = ({
   allowance,
 }) => {
   const ConnectGateOrEmptyFragment = requiresConnected ? ConnectGate : React.Fragment
-  const AllowanceGateOrEmptyFragment: React.FC = allowance
-    ? (children) => (
-        <AllowanceGate spender={allowance.spender} amount={allowance.amount}>
-          {children}
-        </AllowanceGate>
-      )
-    : React.Fragment
 
   const button = (
     <button className={cx(styles.button, styles[variant])} onClick={onClick} disabled={disabled}>
@@ -69,7 +71,7 @@ export const Button: React.FC<ButtonProps> = ({
     button
   ) : (
     <ConnectGateOrEmptyFragment>
-      <AllowanceGateOrEmptyFragment>{button}</AllowanceGateOrEmptyFragment>
+      <AllowanceGateOrEmptyFragment allowance={allowance}>{button}</AllowanceGateOrEmptyFragment>
     </ConnectGateOrEmptyFragment>
   )
 }

--- a/src/pages/Fundraising/Fundraising.tsx
+++ b/src/pages/Fundraising/Fundraising.tsx
@@ -168,7 +168,7 @@ export const FundraisingPage: React.FC = () => {
   const usdcRemaining =
     usdcToSherRewardRatio && sherRemaining && Number(utils.formatUnits(sherRemaining, 18)) / usdcToSherRewardRatio
 
-  const userHasEnoughBalance = usdc.balance && usdcInput && usdc.balance.gte(usdcInput)
+  const userHasInsufficientBalance = (usdc.balance && usdcInput && usdcInput.gt(usdc.balance)) === true
 
   return (
     <Box>
@@ -255,9 +255,9 @@ export const FundraisingPage: React.FC = () => {
                         spender: sherBuyContract.address,
                         amount: usdcInput ? utils.parseUnits(usdcInput.toString(), 6) : BigNumber.from(0),
                       }}
-                      disabled={true}
+                      disabled={userHasInsufficientBalance}
                     >
-                      Insufficient balance
+                      {userHasInsufficientBalance ? "Insufficient Balance" : "Execute"}
                     </Button>
                   </Row>
                 </Column>

--- a/src/pages/Fundraising/Fundraising.tsx
+++ b/src/pages/Fundraising/Fundraising.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react"
 import { BigNumber, ethers, utils } from "ethers"
 import { useDebounce } from "use-debounce"
 
-import AllowanceGate from "../../components/AllowanceGate/AllowanceGate"
 import { Button } from "../../components/Button/Button"
 import { Input } from "../../components/Input"
 import { Box } from "../../components/Box"
@@ -13,7 +12,6 @@ import { Column, Row } from "../../components/Layout"
 import { useSherBuyContract } from "../../hooks/useSherBuyContract"
 import { useSherClaimContract } from "../../hooks/useSherClaimContract"
 import useERC20 from "../../hooks/useERC20"
-import ConnectGate from "../../components/ConnectGate/ConnectGate"
 import useWaitTx from "../../hooks/useWaitTx"
 
 import { formattedTimeDifference } from "../../utils/dates"
@@ -39,6 +37,7 @@ export const FundraisingPage: React.FC = () => {
   const sherBuyContract = useSherBuyContract()
   const sherClaimContract = useSherClaimContract()
   const sher = useERC20("SHER")
+  const usdc = useERC20("USDC")
   const { waitForTx } = useWaitTx()
 
   /**
@@ -169,6 +168,8 @@ export const FundraisingPage: React.FC = () => {
   const usdcRemaining =
     usdcToSherRewardRatio && sherRemaining && Number(utils.formatUnits(sherRemaining, 18)) / usdcToSherRewardRatio
 
+  const userHasEnoughBalance = usdc.balance && usdcInput && usdc.balance.gte(usdcInput)
+
   return (
     <Box>
       <Column spacing="m">
@@ -247,14 +248,17 @@ export const FundraisingPage: React.FC = () => {
                     </Column>
                   </Row>
                   <Row alignment="center">
-                    <ConnectGate>
-                      <AllowanceGate
-                        spender={sherBuyContract.address}
-                        amount={usdcInput ? utils.parseUnits(usdcInput.toString(), 6) : BigNumber.from(0)}
-                      >
-                        <Button onClick={handleExecute}>Execute</Button>
-                      </AllowanceGate>
-                    </ConnectGate>
+                    <Button
+                      onClick={handleExecute}
+                      requiresConnected
+                      allowance={{
+                        spender: sherBuyContract.address,
+                        amount: usdcInput ? utils.parseUnits(usdcInput.toString(), 6) : BigNumber.from(0),
+                      }}
+                      disabled={true}
+                    >
+                      Insufficient balance
+                    </Button>
                   </Row>
                 </Column>
               </Row>


### PR DESCRIPTION
This is an attempt to couple `ConnectGate` & `AllowanceGate` into `Button` component.

There're several reasons to make `Button` aware of this HOCs:

One of them 👇🏽 

- Disabled states: with the current implementation, is impossible to render a disabled button before the gates' conditions are met. e.g: `ConnectGate` will display a "Connect" button, then `AllowanceGate` will display an "Approve" button and only then, the real button will render, with a disabled state.
