### PR TITLE
feat: display claim link only for investors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { Route, Routes, useLocation } from "react-router-dom"
 
 import { StakingPage } from "./pages/Staking"
@@ -13,32 +13,53 @@ import { Header, NavigationLink } from "./components/Header"
 import { routes } from "./utils/routes"
 
 import styles from "./App.module.scss"
+import { useFundraisePosition } from "./hooks/api/useFundraisePosition"
+import { useAccount } from "wagmi"
 
 function App() {
   const location = useLocation()
+  const [{ data: accountData }] = useAccount()
+  const { getFundraisePosition, data: fundraisePositionData } = useFundraisePosition()
+  const [navigationLinks, setNavigationLinks] = useState<NavigationLink[]>([])
 
-  const navigationLinks: NavigationLink[] =
-    location.pathname.endsWith("fundraise") || location.pathname.endsWith("fundraiseclaim")
-      ? [
-          {
-            title: "FUNDRAISE",
-            route: routes.Fundraise,
-          },
+  useEffect(() => {
+    if (accountData?.address) {
+      getFundraisePosition(accountData.address)
+    }
+  }, [accountData?.address, getFundraisePosition])
+
+  useEffect(() => {
+    if (location.pathname.endsWith("fundraise") || location.pathname.endsWith("fundraiseclaim")) {
+      let links: NavigationLink[] = [
+        {
+          title: "FUNDRAISE",
+          route: routes.Fundraise,
+        },
+      ]
+
+      if (fundraisePositionData) {
+        links = [
+          ...links,
           {
             title: "CLAIM",
             route: routes.FundraiseClaim,
           },
         ]
-      : [
-          {
-            title: "STAKE",
-            route: routes.Stake,
-          },
-          {
-            title: "POSITIONS",
-            route: routes.Positions,
-          },
-        ]
+      }
+      setNavigationLinks(links)
+    } else {
+      setNavigationLinks([
+        {
+          title: "STAKE",
+          route: routes.Stake,
+        },
+        {
+          title: "POSITIONS",
+          route: routes.Positions,
+        },
+      ])
+    }
+  }, [location.pathname, fundraisePositionData])
 
   return (
     <div className={styles.app}>

--- a/src/hooks/api/useFundraisePosition.tsx
+++ b/src/hooks/api/useFundraisePosition.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react"
-import { BigNumber } from "ethers"
+import { BigNumber, ethers } from "ethers"
 import axios from "./axios"
 import { getFundraisePosition as getFundraisePositionUrl } from "./urls"
 
@@ -61,7 +61,8 @@ export const FundraisePositionProvider: React.FC = ({ children }) => {
     try {
       setLoading(true)
 
-      const response = await axios.get<GetFundraisePositionResponseData>(getFundraisePositionUrl(account))
+      const checksummedAddress = ethers.utils.getAddress(account)
+      const response = await axios.get<GetFundraisePositionResponseData>(getFundraisePositionUrl(checksummedAddress))
 
       setData(parseResponse(response.data))
       setError(null)

--- a/src/hooks/api/useFundraisePosition.tsx
+++ b/src/hooks/api/useFundraisePosition.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react"
+import React, { useCallback, useState } from "react"
 import { BigNumber } from "ethers"
 import axios from "./axios"
 import { getFundraisePosition as getFundraisePositionUrl } from "./urls"
@@ -39,10 +39,23 @@ const parseResponse = (response: GetFundraisePositionResponseData): FundraisePos
   }
 }
 
+type FundraisePositionContextType = {
+  getFundraisePosition: (account: string) => void
+  loading: boolean
+  data: FundraisePosition | null
+  error: Error | null
+}
+
+const FundraisePositionContext = React.createContext<FundraisePositionContextType>({} as FundraisePositionContextType)
+
 export const useFundraisePosition = () => {
+  return React.useContext(FundraisePositionContext)
+}
+
+export const FundraisePositionProvider: React.FC = ({ children }) => {
   const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<Error | null>()
-  const [data, setData] = useState<FundraisePosition | null>()
+  const [error, setError] = useState<Error | null>(null)
+  const [data, setData] = useState<FundraisePosition | null>(null)
 
   const getFundraisePosition = useCallback(async (account: string) => {
     try {
@@ -60,10 +73,15 @@ export const useFundraisePosition = () => {
     }
   }, [])
 
-  return {
-    getFundraisePosition,
-    loading,
-    data,
-    error,
-  }
+  const ctx = React.useMemo(
+    () => ({
+      getFundraisePosition,
+      loading,
+      data,
+      error,
+    }),
+    [getFundraisePosition, loading, data, error]
+  )
+
+  return <FundraisePositionContext.Provider value={ctx}>{children}</FundraisePositionContext.Provider>
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import reportWebVitals from "./reportWebVitals"
 import { ApolloProvider } from "./utils/apollo/ApolloProvider"
 import { WagmiProvider } from "./utils/WagmiProvider"
 import { TxWaitProvider } from "./hooks/useWaitTx"
+import { FundraisePositionProvider } from "./hooks/api/useFundraisePosition"
 
 global.Buffer = global.Buffer || require("buffer").Buffer
 
@@ -17,7 +18,9 @@ ReactDOM.render(
       <WagmiProvider>
         <ApolloProvider>
           <TxWaitProvider>
-            <App />
+            <FundraisePositionProvider>
+              <App />
+            </FundraisePositionProvider>
           </TxWaitProvider>
         </ApolloProvider>
       </WagmiProvider>

--- a/src/pages/Fundraising/Fundraising.tsx
+++ b/src/pages/Fundraising/Fundraising.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react"
 import { BigNumber, ethers, utils } from "ethers"
 import { useDebounce } from "use-debounce"
+import { useNavigate } from "react-router-dom"
 
 import AllowanceGate from "../../components/AllowanceGate/AllowanceGate"
 import { Button } from "../../components/Button/Button"
@@ -37,6 +38,7 @@ type Rewards = {
 }
 
 export const FundraisingPage: React.FC = () => {
+  const navigate = useNavigate()
   const sherBuyContract = useSherBuyContract()
   const sherClaimContract = useSherClaimContract()
   const sher = useERC20("SHER")
@@ -165,6 +167,7 @@ export const FundraisingPage: React.FC = () => {
 
     try {
       await waitForTx(async () => await sherBuyContract.execute(rewards?.sherAmount))
+      navigate("/fundraiseclaim")
     } catch (error) {
       console.error(error)
     }


### PR DESCRIPTION
- `Claim` header link only becomes visible if the current account has an active position in the fundraise.
- User is automatically redirected to Claim page after a successful purchase.