### PR TITLE
fix: local provider url

### DIFF
--- a/src/utils/WagmiProvider.tsx
+++ b/src/utils/WagmiProvider.tsx
@@ -41,7 +41,7 @@ const provider = ({ chainId }: { chainId?: number | undefined }) => {
   console.log("Fetching provider for chain", chainId)
 
   // Use local node if working on a development chain
-  if (__DEV__ && (chainId === localNetworkId || !chainId)) {
+  if (__DEV__ && chainId && chainId === localNetworkId) {
     return new providers.JsonRpcProvider("http://127.0.0.1:8545")
   }
 


### PR DESCRIPTION
Had a few issues working locally but set up on the Goerli network. In particular, at app startup, the first call comes with empty `chainId` which triggers the local RPC node url, and leads to a few errors.

Thought that checking for local environment should be a bit more restrictive, but would like to check with you on this.