### PR TITLE
Make state assumptions to mitigate amount of RPC calls

### DIFF
--- a/src/hooks/useERC20.ts
+++ b/src/hooks/useERC20.ts
@@ -9,25 +9,31 @@ import { BigNumber, ethers } from "ethers"
  *
  * Adding a new token will update type definitions as well.
  */
-const TokenContracts = {
-  USDC: process.env.REACT_APP_USDC_ADDRESS as string,
-  SHER: process.env.REACT_APP_SHER_ADDRESS as string,
+const TokenData = {
+  USDC: {
+    contract: process.env.REACT_APP_USDC_ADDRESS as string,
+    decimals: 6,
+  },
+  SHER: {
+    contract: process.env.REACT_APP_SHER_ADDRESS as string,
+    decimals: 18,
+  },
 }
 
-type AvailableERC20Tokens = keyof typeof TokenContracts
+type AvailableERC20Tokens = keyof typeof TokenData
 
 /**
  * Hook for interacting with an ERC20 token contract
  * @param token ERC20 Token
  * @param contractAddress Contract address for an ERC20 token
  */
-const useERC20 = (token?: AvailableERC20Tokens, contractAddress?: string) => {
-  const address = token ? TokenContracts[token] : contractAddress
+const useERC20 = (token: AvailableERC20Tokens) => {
+  const address = TokenData[token].contract
   if (!address) {
     throw Error("Address or token name required")
   }
 
-  const [decimals, setDecimals] = React.useState<number>(18)
+  const decimals = TokenData[token].decimals
   const [balance, setBalance] = React.useState<BigNumber>()
   const [allowances, setAllowances] = React.useState<{ [key: string]: BigNumber }>({})
 
@@ -118,24 +124,6 @@ const useERC20 = (token?: AvailableERC20Tokens, contractAddress?: string) => {
 
     refreshBalance()
   }, [accountData?.address, refreshBalance])
-
-  /**
-   * Fetch ERC20 metadata on initialization
-   */
-  React.useEffect(() => {
-    if (!contract) {
-      return
-    }
-
-    const fetchERC20metadata = async () => {
-      const tokenDecimals = await contract.decimals()
-      if (tokenDecimals) {
-        setDecimals(tokenDecimals)
-      }
-    }
-
-    fetchERC20metadata()
-  }, [contract])
 
   return React.useMemo(
     () => ({ balance, refreshBalance, getBalanceOf, getAllowance, approve, decimals, format }),

--- a/src/hooks/useSherBuyContract.ts
+++ b/src/hooks/useSherBuyContract.ts
@@ -57,18 +57,8 @@ export const useSherBuyContract = () => {
    * @returns USDC/SHER ratio
    * @see https://github.com/sherlock-protocol/sherlock-v2-core/blob/main/contracts/SherBuy.sol
    */
-  const getUsdcToSherRewardRatio = useCallback(async () => {
-    const stakeRate = await contract.stakeRate()
-    const buyRate = await contract.buyRate()
-
-    const convertedStakeRate = Number(ethers.utils.formatUnits(stakeRate, 6))
-    const convertedBuyRate = Number(ethers.utils.formatUnits(buyRate, 6))
-
-    const ratio = convertedBuyRate / (convertedBuyRate + convertedStakeRate)
-
-    return ratio
-  }, [contract])
-
+  // This will be 0.1 (not going to change ever)
+  const getUsdcToSherRewardRatio = 0.1
   /**
    * Fetch USDC needed to buy up to `sherAmountWant` SHER tokens
    *

--- a/src/hooks/useSherClaimContract.ts
+++ b/src/hooks/useSherClaimContract.ts
@@ -5,7 +5,8 @@ import { SherClaim } from "../contracts/SherClaim"
 import useWaitTx from "./useWaitTx"
 
 export const SHER_CLAIM_ADDRESS = process.env.REACT_APP_SHER_CLAIM_ADDRESS as string
-
+const ENV_DEADLINE = parseInt(process.env.REACT_APP_SHER_BUY_ENTRY_DEADLINE || "")
+export const SHER_BUY_ENTRY_DEADLINE = Number.isInteger(ENV_DEADLINE) ? ENV_DEADLINE : 0
 /**
  * React Hook for interacting with Sherlock's SerClaim smart contract.
  *
@@ -31,9 +32,8 @@ export const useSherClaimContract = () => {
    * @see `claimableAt` smart contract property.
    */
   const getClaimableAt = useCallback(async () => {
-    const timestampInSeconds = await contract.claimableAt()
     // Convert timestamp to milliseconds and return date obj
-    return new Date(timestampInSeconds.toNumber() * 1000)
+    return new Date(SHER_BUY_ENTRY_DEADLINE * 1000)
   }, [contract])
 
   /**

--- a/src/pages/Fundraising/Fundraising.tsx
+++ b/src/pages/Fundraising/Fundraising.tsx
@@ -75,7 +75,7 @@ export const FundraisingPage: React.FC = () => {
   useEffect(() => {
     const fetchConversionRatio = async () => {
       try {
-        const ratio = await sherBuyContract.getUsdcToSherRewardRatio()
+        const ratio = await sherBuyContract.getUsdcToSherRewardRatio
         setUsdcToSherRewardRatio(ratio)
       } catch (error) {
         console.error(error)


### PR DESCRIPTION
Currently the "Event ends" field is broken because the `claimableAt()` function has been removed from the contracts. `claimableAt()` used to represent both the end of the fundraise period + the start of the claim period. This has changed.

> WARNING! Please verify if the removal of this function doesn't cause problems elsewhere.

This PR
- Hard codes token decimals
- Hard codes USDC -> SHER ratio
- Makes deadline configurable with environment variable (`REACT_APP_SHER_BUY_ENTRY_DEADLINE`)

**For both Goerli and Mainnet deployment, the following is true.**

Fundraise deadline (`REACT_APP_SHER_BUY_ENTRY_DEADLINE`) = `1647100800`
Claim timestamp = `1662825600` (calculated by `1647100800` + 26 weeks (`15724800`)