### PR TITLE
Set open graph metas

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
     <meta property="og:description" content="Sherlock is a protocol on the Ethereum blockchain that protects Decentralized Finance (DeFi) users from smart contract exploits with proprietary security analysis and protocol-level coverage.">
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://i.imgur.com/bQxJd02.png">
+    <meta name="twitter:card" content="summary_large_image">
 
 
     <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png" />

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Sherlock Protocol" />
 
+    <meta property="og:title" content="Sherlock">
+    <meta property="og:site_name" content="Sherlock Protocol">
+    <meta property="og:url" content="https://app.sherlock.xyz">
+    <meta property="og:description" content="Sherlock is a protocol on the Ethereum blockchain that protects Decentralized Finance (DeFi) users from smart contract exploits with proprietary security analysis and protocol-level coverage.">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://i.imgur.com/bQxJd02.png">
+
+
     <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon-16x16.png" />


### PR DESCRIPTION
Set Open Graph metas so that app links will show up nicely when being shared on Discord/Twitter/etc:

### Old:
#### Discord
<img width="292" alt="Screenshot 2022-03-02 at 15 04 46" src="https://user-images.githubusercontent.com/1048185/156367119-6f9e399e-dbf3-4861-8059-717ebef3d65d.png">

#### Twitter
![Screenshot 2022-03-02 at 15 07 20](https://user-images.githubusercontent.com/1048185/156367397-f500c0fc-3a33-4b4d-a432-71e0e51fbb32.png)


### New:
#### Discord
<img width="456" alt="Screenshot 2022-03-02 at 15 17 28" src="https://user-images.githubusercontent.com/1048185/156368997-c86f4f54-9554-4e66-9014-6dcd92d6c2eb.png">

#### Twitter
![Screenshot 2022-03-02 at 15 18 06](https://user-images.githubusercontent.com/1048185/156369084-ed40066b-f53d-4643-a450-93c9dc69770b.png)


I have used this https://i.imgur.com/bQxJd02.png image, but can be changed at any point.

