### PR TITLE
Custom tx modal messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # App Settings
 REACT_APP_LAUNCH_TIMESTAMP=0
+REACT_APP_SHER_BUY_ENTRY_DEADLINE=1647100800
 
 # Alchemy project API url
 REACT_APP_ALCHEMY_API_URL=https://eth-goerli.alchemyapi.io/v2/Iumug7WXyG4Yh5BXEuss9pOMPSIq4BTU

--- a/src/components/AllowanceGate/AllowanceGate.tsx
+++ b/src/components/AllowanceGate/AllowanceGate.tsx
@@ -3,6 +3,7 @@ import React from "react"
 import { FaArrowRight } from "react-icons/fa"
 import useERC20 from "../../hooks/useERC20"
 import useWaitTx from "../../hooks/useWaitTx"
+import { TxType } from "../../utils/txModalMessages"
 import { Button } from "../Button/Button"
 import { Row } from "../Layout"
 import styles from "./AllowanceGate.module.scss"
@@ -50,7 +51,9 @@ const AllowanceGate: React.FC<Props> = ({ children, spender, amount, render }) =
       return
     }
 
-    await waitForTx(async () => (await approve(spender, amount)) as ethers.ContractTransaction)
+    await waitForTx(async () => (await approve(spender, amount)) as ethers.ContractTransaction, {
+      transactionType: TxType.APPROVE,
+    })
 
     handleFetchAllowance(true)
   }, [approve, spender, amount, handleFetchAllowance, waitForTx])

--- a/src/components/TxStateModals/PendingTx.tsx
+++ b/src/components/TxStateModals/PendingTx.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import TransactionTypeMessages, { TxType } from "../../utils/txModalMessages"
 import { Column } from "../Layout"
 import Loading from "../Loading/Loading"
 import Modal from "../Modal/Modal"
@@ -7,17 +8,24 @@ import TxHash from "./TxHash"
 
 interface Props {
   /**
+   * Transaction type
+   */
+  type: TxType
+
+  /**
    * Transaction hash
    */
   hash?: string
 }
 
-const PendingTx: React.FC<Props> = ({ hash }) => {
+const PendingTx: React.FC<Props> = ({ type, hash }) => {
   return (
     <Modal>
       <Column spacing="m" alignment="center">
-        <Loading variant="Layer" label="Transaction approved and pending" />
-        <Text>Waiting for the transaction to make it's way on the blockchain.</Text>
+        <Loading variant="Layer" label={TransactionTypeMessages[type].PENDING.title} />
+        {TransactionTypeMessages[type].PENDING.messages.map((message, index) => (
+          <Text key={index}>{message}</Text>
+        ))}
         {hash && <TxHash hash={hash} />}
       </Column>
     </Modal>

--- a/src/components/TxStateModals/SuccessTx.tsx
+++ b/src/components/TxStateModals/SuccessTx.tsx
@@ -4,23 +4,31 @@ import TxHash from "./TxHash"
 import { Column } from "../Layout"
 import SuccessIcon from "../SuccessIcon/SuccessIcon"
 import { Text } from "../Text"
+import TransactionTypeMessages, { TxType } from "../../utils/txModalMessages"
 
 interface Props {
+  /**
+   * Transaction type
+   */
+  type: TxType
+
   /**
    * Transaction hash
    */
   hash?: string
 }
 
-const SuccessTx: React.FC<Props> = ({ hash }) => {
+const SuccessTx: React.FC<Props> = ({ type, hash }) => {
   return (
     <Modal closeable>
       <Column spacing="m" alignment="center">
         <SuccessIcon />
         <Text strong size="large">
-          Transaction was successful!
+          {TransactionTypeMessages[type].SUCCESS.title}
         </Text>
-        <Text>Yipeee! The transaction maade it's way on the blockchain!</Text>
+        {TransactionTypeMessages[type].SUCCESS.messages.map((message, index) => (
+          <Text key={index}>{message}</Text>
+        ))}
         {hash && <TxHash hash={hash} />}
       </Column>
     </Modal>

--- a/src/hooks/useWaitTx.tsx
+++ b/src/hooks/useWaitTx.tsx
@@ -5,21 +5,13 @@ import RequestedTx from "../components/TxStateModals/RequestedTx"
 import RevertedTx from "../components/TxStateModals/RevertedTx"
 import SuccessTx from "../components/TxStateModals/SuccessTx"
 import UserDeniedTx from "../components/TxStateModals/UserDeniedTx"
+import { TxState, TxType } from "../utils/txModalMessages"
 
 interface TxWaitContextType {
   waitForTx: (tx: () => Promise<ethers.ContractTransaction>) => Promise<ethers.ContractReceipt>
 }
 
 const TxWaitContext = React.createContext<TxWaitContextType>({} as TxWaitContextType)
-
-enum TxState {
-  NONE = 1,
-  REQUESTED = 2,
-  PENDING = 3,
-  SUCCESS = 4,
-  REVERTED = 5,
-  USER_DENIED = 6,
-}
 
 /**
  * Provider for waiting for a pending transaction and show
@@ -28,11 +20,22 @@ enum TxState {
 export const TxWaitProvider: React.FC = ({ children }) => {
   const [txState, setTxState] = React.useState(TxState.NONE)
   const [txHash, setTxHash] = React.useState<string | undefined>()
+  const [txType, setTxType] = React.useState<TxType>(TxType.GENERIC)
 
+  /**
+   * Wrap a contract transaction and follow transaction state changes
+   * with visual updates.
+   */
   const waitForTx = React.useCallback(
-    async (tx: () => Promise<ethers.ContractTransaction>): Promise<ethers.ContractReceipt> => {
+    async (
+      tx: () => Promise<ethers.ContractTransaction>,
+      options?: {
+        transactionType?: TxType
+      }
+    ): Promise<ethers.ContractReceipt> => {
       setTxHash(undefined)
       setTxState(TxState.REQUESTED)
+      setTxType(options?.transactionType ?? TxType.GENERIC)
 
       try {
         const transaction = await tx()
@@ -65,8 +68,8 @@ export const TxWaitProvider: React.FC = ({ children }) => {
     <TxWaitContext.Provider value={ctx}>
       {children}
       {txState === TxState.REQUESTED && <RequestedTx />}
-      {txState === TxState.PENDING && <PendingTx hash={txHash} />}
-      {txState === TxState.SUCCESS && <SuccessTx hash={txHash} />}
+      {txState === TxState.PENDING && <PendingTx type={txType} hash={txHash} />}
+      {txState === TxState.SUCCESS && <SuccessTx type={txType} hash={txHash} />}
       {txState === TxState.REVERTED && <RevertedTx hash={txHash} />}
       {txState === TxState.USER_DENIED && <UserDeniedTx />}
     </TxWaitContext.Provider>

--- a/src/hooks/useWaitTx.tsx
+++ b/src/hooks/useWaitTx.tsx
@@ -8,7 +8,12 @@ import UserDeniedTx from "../components/TxStateModals/UserDeniedTx"
 import { TxState, TxType } from "../utils/txModalMessages"
 
 interface TxWaitContextType {
-  waitForTx: (tx: () => Promise<ethers.ContractTransaction>) => Promise<ethers.ContractReceipt>
+  waitForTx: (
+    tx: () => Promise<ethers.ContractTransaction>,
+    options?: {
+      transactionType?: TxType
+    }
+  ) => Promise<ethers.ContractReceipt>
 }
 
 const TxWaitContext = React.createContext<TxWaitContextType>({} as TxWaitContextType)

--- a/src/pages/Fundraising/Fundraising.tsx
+++ b/src/pages/Fundraising/Fundraising.tsx
@@ -21,6 +21,7 @@ import { formattedTimeDifference } from "../../utils/dates"
 import styles from "./Fundraising.module.scss"
 import TokenInput from "../../components/TokenInput/TokenInput"
 import LoadingContainer from "../../components/LoadingContainer/LoadingContainer"
+import { TxType } from "../../utils/txModalMessages"
 
 type Rewards = {
   /**
@@ -166,7 +167,9 @@ export const FundraisingPage: React.FC = () => {
     if (!rewards?.sherAmount) return
 
     try {
-      await waitForTx(async () => await sherBuyContract.execute(rewards?.sherAmount))
+      await waitForTx(async () => await sherBuyContract.execute(rewards?.sherAmount), {
+        transactionType: TxType.EXECUTE,
+      })
       navigate("/fundraiseclaim")
     } catch (error) {
       console.error(error)

--- a/src/pages/Staking/Staking.tsx
+++ b/src/pages/Staking/Staking.tsx
@@ -16,6 +16,7 @@ import useERC20 from "../../hooks/useERC20"
 import useSherDistManager from "../../hooks/useSherDistManager"
 import useSherlock from "../../hooks/useSherlock"
 import useWaitTx from "../../hooks/useWaitTx"
+import { TxType } from "../../utils/txModalMessages"
 import styles from "./Staking.module.scss"
 
 /**
@@ -74,7 +75,9 @@ export const StakingPage: React.FC = () => {
       return
     }
 
-    await waitForTx(async () => (await stake(amount, stakingPeriod)) as ethers.ContractTransaction)
+    await waitForTx(async () => (await stake(amount, stakingPeriod)) as ethers.ContractTransaction, {
+      transactionType: TxType.STAKE,
+    })
 
     refreshTvl()
   }, [amount, stakingPeriod, stake, refreshTvl, waitForTx])

--- a/src/utils/txModalMessages.tsx
+++ b/src/utils/txModalMessages.tsx
@@ -1,0 +1,108 @@
+/**
+ * Types of transactions: ERC20 token approval,
+ * fundraise participation, staking, restaking, etc.
+ */
+export enum TxType {
+  GENERIC = "GENERIC",
+  APPROVE = "APPROVE",
+  EXECUTE = "EXECUTE",
+  STAKE = "STAKE",
+  RESTAKE = "RESTAKE",
+}
+
+/**
+ * State of a transaction.
+ *
+ * NONE: No transaction initiated.
+ * REQUESTED: dApp requested a transaction and is waiting for wallet interaction.
+ * USER_DENIED: Transaction was rejected from the wallet.
+ * PENDING: Transaction was approved from the wallet and is waiting to be mined.
+ * SUCCESS: Transaction was mined and confirmed onto the blockchain.
+ * REVERTED: Transaction was mined but was not successful.
+ */
+export enum TxState {
+  NONE = "NONE",
+  REQUESTED = "REQUESTED",
+  PENDING = "PENDING",
+  SUCCESS = "SUCCESS",
+  REVERTED = "REVERTED",
+  USER_DENIED = "USER_DENIED",
+}
+
+type ModalMessage = {
+  /**
+   * Modal title
+   */
+  title: string
+
+  /**
+   * Modal body. Each string will be rendered on a separate line.
+   */
+  messages: Array<string>
+}
+
+/**
+ * Modal messages for different transaction types and states.
+ *
+ * Example: TxTypeMessages.APPROVE.SUCCESS.message
+ */
+type TxTypeMessages = {
+  [key in TxType]: {
+    [key in Exclude<TxState, TxState.NONE | TxState.USER_DENIED | TxState.REQUESTED | TxState.REVERTED>]: ModalMessage
+  }
+}
+
+const TransactionTypeMessages: TxTypeMessages = {
+  [TxType.GENERIC]: {
+    [TxState.PENDING]: {
+      title: "Transaction approved and pending",
+      messages: ["Waiting for the transaction to make its way onto the blockchain."],
+    },
+    [TxState.SUCCESS]: {
+      title: "Transaction was successful!",
+      messages: ["Yipeee!! The transaction made its way onto the blockchain!"],
+    },
+  },
+  [TxType.APPROVE]: {
+    [TxState.PENDING]: {
+      title: "Transaction approved and pending",
+      messages: ["Waiting for the approval transaction (1/2) to make its way onto the blockchain."],
+    },
+    [TxState.SUCCESS]: {
+      title: "Transaction was successful!",
+      messages: ["Yipeee!!Approval transaction (2/2) is completed. The next transaction (2/2) is ready to be signed."],
+    },
+  },
+  [TxType.EXECUTE]: {
+    [TxState.PENDING]: {
+      title: "Transaction approved and pending",
+      messages: ["Waiting for the execute transaction (2/2) to make its way onto the blockchain."],
+    },
+    [TxState.SUCCESS]: {
+      title: "Transaction was successful!",
+      messages: ["Yipeee!! Execute transaction (2/2) is completed. Look into your wallet for the receipt NFT."],
+    },
+  },
+  [TxType.STAKE]: {
+    [TxState.PENDING]: {
+      title: "Transaction approved and pending",
+      messages: ["Waiting for the transaction to make its way onto the blockchain."],
+    },
+    [TxState.SUCCESS]: {
+      title: "Transaction was successful!",
+      messages: ["Yipeee!! The transaction made its way onto the blockchain!"],
+    },
+  },
+  [TxType.RESTAKE]: {
+    [TxState.PENDING]: {
+      title: "Transaction approved and pending",
+      messages: ["Waiting for the transaction to make its way onto the blockchain."],
+    },
+    [TxState.SUCCESS]: {
+      title: "Transaction was successful!",
+      messages: ["Yipeee!! The transaction made its way onto the blockchain!"],
+    },
+  },
+}
+
+export default TransactionTypeMessages

--- a/src/utils/txModalMessages.tsx
+++ b/src/utils/txModalMessages.tsx
@@ -70,7 +70,7 @@ const TransactionTypeMessages: TxTypeMessages = {
     },
     [TxState.SUCCESS]: {
       title: "Transaction was successful!",
-      messages: ["Yipeee!! Approval transaction (2/2) is completed. The next transaction (2/2) is ready to be signed."],
+      messages: ["Yipeee!! Approval transaction (1/2) is completed. The next transaction (2/2) is ready to be signed."],
     },
   },
   [TxType.EXECUTE]: {

--- a/src/utils/txModalMessages.tsx
+++ b/src/utils/txModalMessages.tsx
@@ -60,7 +60,7 @@ const TransactionTypeMessages: TxTypeMessages = {
     },
     [TxState.SUCCESS]: {
       title: "Transaction was successful!",
-      messages: ["Yipeee!! The transaction made its way onto the blockchain!"],
+      messages: ["Success!! The transaction made its way onto the blockchain!"],
     },
   },
   [TxType.APPROVE]: {
@@ -70,7 +70,9 @@ const TransactionTypeMessages: TxTypeMessages = {
     },
     [TxState.SUCCESS]: {
       title: "Transaction was successful!",
-      messages: ["Yipeee!! Approval transaction (1/2) is completed. The next transaction (2/2) is ready to be signed."],
+      messages: [
+        "Success!! Approval transaction (1/2) is completed. The next transaction (2/2) is ready to be signed.",
+      ],
     },
   },
   [TxType.EXECUTE]: {
@@ -80,7 +82,7 @@ const TransactionTypeMessages: TxTypeMessages = {
     },
     [TxState.SUCCESS]: {
       title: "Transaction was successful!",
-      messages: ["Yipeee!! Execute transaction (2/2) is completed. Look into your wallet for the receipt NFT."],
+      messages: ["Success!! Execute transaction (2/2) is completed. Look into your wallet for the receipt NFT."],
     },
   },
   [TxType.STAKE]: {
@@ -90,7 +92,7 @@ const TransactionTypeMessages: TxTypeMessages = {
     },
     [TxState.SUCCESS]: {
       title: "Transaction was successful!",
-      messages: ["Yipeee!! Stake transaction (2/2) is completed. Look into your wallet for the receipt NFT."],
+      messages: ["Success!! Stake transaction (2/2) is completed. Look into your wallet for the receipt NFT."],
     },
   },
   [TxType.ADD_PROTOCOL_BALANCE]: {
@@ -100,7 +102,7 @@ const TransactionTypeMessages: TxTypeMessages = {
     },
     [TxState.SUCCESS]: {
       title: "Transaction was successful!",
-      messages: ["Yipeee!! Add balance transaction (2/2) is completed. Protocol's balance will update shortly."],
+      messages: ["Success!! Add balance transaction (2/2) is completed. Protocol's balance will update shortly."],
     },
   },
 }

--- a/src/utils/txModalMessages.tsx
+++ b/src/utils/txModalMessages.tsx
@@ -7,7 +7,7 @@ export enum TxType {
   APPROVE = "APPROVE",
   EXECUTE = "EXECUTE",
   STAKE = "STAKE",
-  RESTAKE = "RESTAKE",
+  ADD_PROTOCOL_BALANCE = "ADD_PROTOCOL_BALANCE",
 }
 
 /**
@@ -70,7 +70,7 @@ const TransactionTypeMessages: TxTypeMessages = {
     },
     [TxState.SUCCESS]: {
       title: "Transaction was successful!",
-      messages: ["Yipeee!!Approval transaction (2/2) is completed. The next transaction (2/2) is ready to be signed."],
+      messages: ["Yipeee!! Approval transaction (2/2) is completed. The next transaction (2/2) is ready to be signed."],
     },
   },
   [TxType.EXECUTE]: {
@@ -86,21 +86,21 @@ const TransactionTypeMessages: TxTypeMessages = {
   [TxType.STAKE]: {
     [TxState.PENDING]: {
       title: "Transaction approved and pending",
-      messages: ["Waiting for the transaction to make its way onto the blockchain."],
+      messages: ["Waiting for the stake transaction (2/2) to make its way onto the blockchain."],
     },
     [TxState.SUCCESS]: {
       title: "Transaction was successful!",
-      messages: ["Yipeee!! The transaction made its way onto the blockchain!"],
+      messages: ["Yipeee!! Stake transaction (2/2) is completed. Look into your wallet for the receipt NFT."],
     },
   },
-  [TxType.RESTAKE]: {
+  [TxType.ADD_PROTOCOL_BALANCE]: {
     [TxState.PENDING]: {
       title: "Transaction approved and pending",
-      messages: ["Waiting for the transaction to make its way onto the blockchain."],
+      messages: ["Waiting for the add balance transaction (2/2) to make its way onto the blockchain."],
     },
     [TxState.SUCCESS]: {
       title: "Transaction was successful!",
-      messages: ["Yipeee!! The transaction made its way onto the blockchain!"],
+      messages: ["Yipeee!! Add balance transaction (2/2) is completed. Protocol's balance will update shortly."],
     },
   },
 }


### PR DESCRIPTION
Created a system to add custom modal messages for each transaction type and each transaction state.

At the moment, only **Approve**, **Stake**, **Execute** and **Protocol add balance** methods are using custom messages.

As this way of doing it is a bit opinionated, feel free to leave your opinions as well.