### PR TITLE
WalletConnect denied tx message

### DIFF
--- a/src/hooks/useWaitTx.tsx
+++ b/src/hooks/useWaitTx.tsx
@@ -54,7 +54,7 @@ export const TxWaitProvider: React.FC = ({ children }) => {
         return receipt
       } catch (error: any) {
         // User denied transaction (EIP-1193)
-        if (error?.code === 4001) {
+        if (error?.code === 4001 || error === "User rejected the transaction") {
           setTxState(TxState.USER_DENIED)
         } else {
           setTxState(TxState.REVERTED)


### PR DESCRIPTION
Was checking for wallet rejected tx by error code, but WalletConnect throws string messages instead of error objects.
Added a new check so that WalletConnect rejected txs will not show up as Reverted (which implies they were mined, and gas was paid).