### PR TITLE
feat: set a hardcap of 20m for stakers

### DIFF
--- a/src/components/Text/Text.module.scss
+++ b/src/components/Text/Text.module.scss
@@ -1,4 +1,8 @@
 .text {
+  &.warning {
+    color: red;
+  }
+
   &.strong {
     font-weight: 700;
   }

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -5,7 +5,7 @@ import styles from "./Text.module.scss"
 
 type TextSize = "tiny" | "small" | "normal" | "large" | "extra-large"
 
-type TextVariant = "normal" | "primary" | "secondary" | "mono"
+type TextVariant = "normal" | "primary" | "secondary" | "mono" | "warning"
 
 type TextProps = {
   strong?: boolean

--- a/src/pages/Staking/Staking.tsx
+++ b/src/pages/Staking/Staking.tsx
@@ -1,7 +1,8 @@
 import { BigNumber, ethers } from "ethers"
-import React, { useMemo } from "react"
+import React, { useMemo, useState } from "react"
 import { useDebounce } from "use-debounce"
 import { useAccount } from "wagmi"
+import { utils } from "ethers"
 import AllowanceGate from "../../components/AllowanceGate/AllowanceGate"
 import { Box } from "../../components/Box"
 import { Button } from "../../components/Button/Button"
@@ -19,6 +20,7 @@ import useWaitTx from "../../hooks/useWaitTx"
 import { formatAmount } from "../../utils/format"
 import { TxType } from "../../utils/txModalMessages"
 import styles from "./Staking.module.scss"
+import { formatUnits } from "ethers/lib/utils"
 
 /**
  * Available staking periods, in seconds.
@@ -30,9 +32,14 @@ export const PERIODS_IN_SECONDS = {
   ONE_YEAR: 60 * 60 * 24 * 7 * 52,
 }
 
+const TVL_TRESHOLD = BigNumber.from("20000000000000")
+
 export const StakingPage: React.FC = () => {
   const [amount, setAmount] = React.useState<BigNumber>()
-  const [debouncedAmountBN] = useDebounce(amount, 500)
+  const [hardcapAmount, setHardcapAmount] = useState<BigNumber>()
+  const [debouncedAmountBN] = useDebounce(amount, 500, {
+    equalityFn: (l, r) => (r ? !!l?.eq(r) : l === undefined),
+  })
   // We're removing the 12 months period just for March 30th liquidity event.
   const [stakingPeriod] = React.useState<number>(PERIODS_IN_SECONDS.SIX_MONTHS)
   const [sherRewards, setSherRewards] = React.useState<BigNumber>()
@@ -47,10 +54,10 @@ export const StakingPage: React.FC = () => {
   const [{ data: accountData }] = useAccount()
 
   /**
-   * March 30th event: Disable staking once 10M TVL is reached.
+   * April 7th event: Disable staking once 20M TVL is reached.
    */
   const disableStaking = useMemo(() => {
-    return tvl && tvl.gte(BigNumber.from("10000000000000"))
+    return tvl && tvl.gte(TVL_TRESHOLD)
   }, [tvl])
 
   /**
@@ -68,9 +75,24 @@ export const StakingPage: React.FC = () => {
 
     setIsLoadingRewards(true)
 
-    const sher = await computeRewards(tvl, debouncedAmountBN, stakingPeriod)
+    /**
+     * For April 7th event, we're setting a hardcap of 20M.
+     * If the last deposit goes above 20M, we fix that amount to be: 20M - tvl
+     */
+    const futureTVL = tvl.add(debouncedAmountBN)
+    const actualAmount = futureTVL.gt(TVL_TRESHOLD)
+      ? TVL_TRESHOLD.sub(tvl).add(BigNumber.from("1000000"))
+      : debouncedAmountBN
+
+    const sher = await computeRewards(tvl, actualAmount, stakingPeriod)
     if (sher) {
       setSherRewards(sher)
+    }
+
+    if (futureTVL.gt(TVL_TRESHOLD)) {
+      setHardcapAmount(actualAmount)
+    } else {
+      setHardcapAmount(undefined)
     }
 
     setIsLoadingRewards(false)
@@ -126,12 +148,21 @@ export const StakingPage: React.FC = () => {
           <Row className={styles.rewardsContainer}>
             <Column grow={1} spacing="l">
               <TokenInput
+                value={hardcapAmount}
                 onChange={setAmount}
                 token="USDC"
                 placeholder="Choose amount"
                 balance={usdcBalance}
                 disabled={disableStaking}
               />
+              {hardcapAmount && (
+                <Row alignment="center">
+                  <Text variant="warning" size="small" strong>
+                    Warning: Only {utils.commify(formatUnits(hardcapAmount, 6))} USDC will be staked because <br />
+                    the maximum for this round has been reached.
+                  </Text>
+                </Row>
+              )}
               {/* 
               We're removing the 12 months period just for March 30th liquidity event. 6 months by default.
               <Row spacing="m">


### PR DESCRIPTION
- Staking interface will be disabled once 20m is reached.
- Last deposit could be capped if TVL goes above 20m. In this case, we display a warning message.