### PR TITLE
Add unlock chart

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import styles from "./App.module.scss"
 import { useFundraisePosition } from "./hooks/api/useFundraisePosition"
 import { useAccount } from "wagmi"
 import MobileBlock from "./components/MobileBlock/MobileBlock"
+import { InternalOverviewPage } from "./pages/InternalOverview/InternalOverview"
 
 function App() {
   const location = useLocation()
@@ -72,6 +73,7 @@ function App() {
               <Route path={routes.FundraiseClaim} element={<FundraisingClaimPage />} />
               <Route path={routes.Protocol} element={<ProtocolPage />} />
               <Route path={routes.USForbidden} element={<USForbiddenPage />} />
+              <Route path={routes.InternalOverview} element={<InternalOverviewPage />} />
               <Route path="*" element={<Navigate replace to={routes.Stake} />} />
             </Routes>
           </div>

--- a/src/components/APYChart/APYChart.tsx
+++ b/src/components/APYChart/APYChart.tsx
@@ -42,7 +42,9 @@ const APYChart: React.FC = () => {
             width={450}
             height={200}
             data={chartData}
-            tooltipFormatter={(v: number, name: string) => [`${v}%`, "APY"]}
+            tooltipProps={{
+              formatter: (v: number, name: string) => [`${v}%`, "APY"],
+            }}
             yTickFormatter={(v) => `${v}%`}
           />
         </Row>

--- a/src/components/Chart/Chart.tsx
+++ b/src/components/Chart/Chart.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { AreaChart, YAxis, XAxis, Tooltip, Area } from "recharts"
+import { AreaChart, YAxis, XAxis, Tooltip, TooltipProps, Area, XAxisProps, AreaProps } from "recharts"
 
 import { commify, shortenNumber } from "../../utils/units"
 
@@ -8,7 +8,9 @@ type Props = {
   height?: number
   data?: any[]
   yTickFormatter?: (v: number) => string
-  tooltipFormatter?: (v: number, name: string) => [string, string]
+  type?: AreaProps["type"]
+  xAxisProps?: XAxisProps
+  tooltipProps?: TooltipProps<any, any>
 }
 
 export const Chart: React.FC<Props> = ({
@@ -16,7 +18,9 @@ export const Chart: React.FC<Props> = ({
   height,
   data,
   yTickFormatter = (v) => (v > 0 ? `$ ${shortenNumber(v)}` : ""),
-  tooltipFormatter = (v: number, name: string) => [`$${commify(v)}`, name.toUpperCase()],
+  type = "monotone",
+  xAxisProps,
+  tooltipProps,
 }) => {
   return (
     <AreaChart width={width} height={height} data={data}>
@@ -33,16 +37,15 @@ export const Chart: React.FC<Props> = ({
         width={80}
         tickFormatter={yTickFormatter}
       />
-      <XAxis dataKey="name" tick={{ fill: "white", fontSize: "12px" }} tickMargin={5} allowDuplicatedCategory={false} />
-      <Tooltip formatter={tooltipFormatter} itemStyle={{ color: "#19032d" }} labelStyle={{ color: "gray" }} />
-      <Area
-        type="monotone"
-        dataKey="value"
-        stroke="#8414EC"
-        fill="url(#tvl)"
-        fillOpacity={1}
-        isAnimationActive={true}
+      <XAxis
+        dataKey="name"
+        tick={{ fill: "white", fontSize: "12px" }}
+        tickMargin={5}
+        allowDuplicatedCategory={false}
+        {...xAxisProps}
       />
+      <Tooltip itemStyle={{ color: "#19032d" }} labelStyle={{ color: "gray" }} {...tooltipProps} />
+      <Area type={type} dataKey="value" stroke="#8414EC" fill="url(#tvl)" fillOpacity={1} isAnimationActive={true} />
     </AreaChart>
   )
 }

--- a/src/hooks/api/urls.ts
+++ b/src/hooks/api/urls.ts
@@ -1,4 +1,5 @@
 export const getFundraisePosition = (account: string) => `positions/${account}/fundraise`
+export const getUnlockOverTime = () => "stats/unlock"
 export const getAPYOverTime = () => "stats/apy"
 export const getTVLOverTime = () => "stats_tvl"
 export const getTVCOverTIme = () => "stats_tvc"

--- a/src/hooks/api/useUnlockOverTime.tsx
+++ b/src/hooks/api/useUnlockOverTime.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useState } from "react"
+import { BigNumber } from "ethers"
+import axios from "./axios"
+import { getUnlockOverTime as getUnlockOverTimeUrl } from "./urls"
+
+type UnlockDataPoint = {
+  timestamp: number
+  value: BigNumber
+}
+
+type GetUnlockOverTimeResponseData =
+  | {
+      ok: true
+      data: {
+        timestamp: number
+        value: string
+      }[]
+    }
+  | {
+      ok: false
+      error: string
+    }
+
+const parseResponse = (response: GetUnlockOverTimeResponseData): UnlockDataPoint[] | null => {
+  if (response.ok === false) return null
+
+  return response.data.map((r) => ({
+    timestamp: r.timestamp,
+    value: BigNumber.from(r.value),
+  }))
+}
+
+export const useUnlockOverTime = () => {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const [data, setData] = useState<UnlockDataPoint[] | null>(null)
+
+  const getUnlockOverTime = useCallback(async () => {
+    try {
+      setLoading(true)
+
+      const { data: responseData } = await axios.get<GetUnlockOverTimeResponseData>(getUnlockOverTimeUrl())
+
+      if (responseData.ok === true) {
+        setData(parseResponse(responseData))
+      } else {
+        setData(null)
+        setError(new Error(responseData.error))
+      }
+    } catch (error) {
+      console.error(error)
+      setData(null)
+      setError(error as Error)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  return {
+    loading,
+    data,
+    error,
+    getUnlockOverTime,
+  }
+}

--- a/src/pages/InternalOverview/InternalOverview.module.scss
+++ b/src/pages/InternalOverview/InternalOverview.module.scss
@@ -1,0 +1,3 @@
+.container {
+  display: flex;
+}

--- a/src/pages/InternalOverview/InternalOverview.tsx
+++ b/src/pages/InternalOverview/InternalOverview.tsx
@@ -11,7 +11,7 @@ import { formatAmount } from "../../utils/format"
 import { useUnlockOverTime } from "../../hooks/api/useUnlockOverTime"
 
 type ChartDataPoint = {
-  name: string
+  name: number
   value: number
 }
 
@@ -25,20 +25,10 @@ export const InternalOverviewPage: React.FC = () => {
   const unlockChartData = useMemo(() => {
     if (!unlockData) return
 
-    console.log("Unlock data", unlockData)
-
     const chartData: ChartDataPoint[] = unlockData?.map((item) => ({
-      name: DateTime.fromMillis(item.timestamp * 1000).toLocaleString({
-        month: "2-digit",
-        day: "2-digit",
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-      }),
+      name: item.timestamp * 1000,
       value: Number(utils.formatUnits(item.value, 6)),
     }))
-
-    console.log("Chart data", chartData)
 
     return chartData
   }, [unlockData])
@@ -56,7 +46,28 @@ export const InternalOverviewPage: React.FC = () => {
                 width={1000}
                 height={200}
                 data={unlockChartData}
-                tooltipFormatter={(v: number, name: string) => [`$${formatAmount(v, 0)}`, "Active Balance"]}
+                tooltipProps={{
+                  formatter: (v: number, name: string) => [`$${formatAmount(v, 0)}`, "Active Balance"],
+                  labelFormatter: (l: number, payload) =>
+                    DateTime.fromMillis(l).toLocaleString({
+                      year: "numeric",
+                      month: "2-digit",
+                      day: "2-digit",
+                    }),
+                }}
+                xAxisProps={{
+                  type: "number",
+                  scale: "time",
+                  domain: ["dataMin", "dataMax"],
+                  tickFormatter: (v: number) =>
+                    DateTime.fromMillis(v).toLocaleString({
+                      year: "2-digit",
+                      month: "2-digit",
+                      day: "2-digit",
+                    }),
+                  interval: "preserveStartEnd",
+                }}
+                type="stepAfter"
               />
             </Row>
           </Column>

--- a/src/pages/InternalOverview/InternalOverview.tsx
+++ b/src/pages/InternalOverview/InternalOverview.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useMemo } from "react"
+import { utils } from "ethers"
+import { DateTime } from "luxon"
+import { Box } from "../../components/Box"
+import { Column, Row } from "../../components/Layout"
+import { Title } from "../../components/Title"
+import { Chart } from "../../components/Chart/Chart"
+
+import styles from "./InternalOverview.module.scss"
+import { formatAmount } from "../../utils/format"
+import { useUnlockOverTime } from "../../hooks/api/useUnlockOverTime"
+
+type ChartDataPoint = {
+  name: string
+  value: number
+}
+
+export const InternalOverviewPage: React.FC = () => {
+  const { getUnlockOverTime, data: unlockData } = useUnlockOverTime()
+
+  useEffect(() => {
+    getUnlockOverTime()
+  }, [getUnlockOverTime])
+
+  const unlockChartData = useMemo(() => {
+    if (!unlockData) return
+
+    console.log("Unlock data", unlockData)
+
+    const chartData: ChartDataPoint[] = unlockData?.map((item) => ({
+      name: DateTime.fromMillis(item.timestamp * 1000).toLocaleString({
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      }),
+      value: Number(utils.formatUnits(item.value, 6)),
+    }))
+
+    console.log("Chart data", chartData)
+
+    return chartData
+  }, [unlockData])
+
+  return (
+    <Column spacing="m" className={styles.container}>
+      <Row>
+        <Box shadow={false} fullWidth>
+          <Column spacing="m">
+            <Row>
+              <Title variant="h3">UNLOCK PERIODS</Title>
+            </Row>
+            <Row alignment="center">
+              <Chart
+                width={1000}
+                height={200}
+                data={unlockChartData}
+                tooltipFormatter={(v: number, name: string) => [`$${formatAmount(v, 0)}`, "Active Balance"]}
+              />
+            </Row>
+          </Column>
+        </Box>
+      </Row>
+    </Column>
+  )
+}

--- a/src/pages/InternalOverview/index.ts
+++ b/src/pages/InternalOverview/index.ts
@@ -1,0 +1,1 @@
+export { InternalOverviewPage as OverviewPage } from "./InternalOverview"

--- a/src/pages/Overview/Overview.tsx
+++ b/src/pages/Overview/Overview.tsx
@@ -98,7 +98,7 @@ export const OverviewPage: React.FC = () => {
                 width={1000}
                 height={200}
                 data={chartsData?.tvcChartData}
-                tooltipFormatter={(v: number, name: string) => [`$${formatAmount(v, 0)}`, "TVC"]}
+                tooltipProps={{ formatter: (v: number, name: string) => [`$${formatAmount(v, 0)}`, "TVC"] }}
               />
             </Row>
           </Column>
@@ -122,7 +122,7 @@ export const OverviewPage: React.FC = () => {
                 width={450}
                 height={200}
                 data={chartsData?.tvlChartData}
-                tooltipFormatter={(v: number, name: string) => [`$${formatAmount(v, 0)}`, "TVL"]}
+                tooltipProps={{ formatter: (v: number, name: string) => [`$${formatAmount(v, 0)}`, "TVL"] }}
               />
             </Row>
           </Column>
@@ -146,7 +146,7 @@ export const OverviewPage: React.FC = () => {
                 width={450}
                 height={200}
                 data={chartsData?.capitalEfficiencyChartData}
-                tooltipFormatter={(v: number, name: string) => [v.toFixed(2), "Capital efficiency"]}
+                tooltipProps={{ formatter: (v: number, name: string) => [v.toFixed(2), "Capital efficiency"] }}
                 yTickFormatter={(v) => v.toFixed(2)}
               />
             </Row>

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -5,6 +5,7 @@ export const routes = {
   FundraiseClaim: "fundraiseclaim",
   Protocol: "protocol",
   Overview: "overview",
+  InternalOverview: "internal",
   USForbidden: "us",
 } as const
 


### PR DESCRIPTION
<img width="1101" alt="Screenshot 2022-05-17 at 13 01 10" src="https://user-images.githubusercontent.com/1048185/168787399-aa8294ae-c239-4447-ba43-06297be01ad7.png">

Crated the TVL over time with the unlock dates, available on `/internal`