### PR TITLE
feat: protocols navigation menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react"
-import { Route, Routes, useLocation, Navigate } from "react-router-dom"
+import React from "react"
+import { Route, Routes, Navigate } from "react-router-dom"
 
 import { FundraisingClaimPage } from "./pages/FundraisingClaim"
 import { StakingPage } from "./pages/Staking"
@@ -7,77 +7,37 @@ import { StakingPositionsPage } from "./pages/StakingPositions"
 import { USForbiddenPage } from "./pages/USForbidden"
 import { OverviewPage } from "./pages/Overview"
 import { ProtocolPage } from "./pages/Protocol"
+import AppStakers from "./AppStakers"
+import AppProtocols from "./AppProtocols"
 
-import { Footer } from "./components/Footer"
-import { Header, NavigationLink } from "./components/Header"
-
-import { routes } from "./utils/routes"
-
-import styles from "./App.module.scss"
-import { useFundraisePosition } from "./hooks/api/useFundraisePosition"
-import { useAccount } from "wagmi"
+import { routes, protocolsRoutes } from "./utils/routes"
 import MobileBlock from "./components/MobileBlock/MobileBlock"
 
 function App() {
-  const location = useLocation()
-  const [{ data: accountData }] = useAccount()
-  const { getFundraisePosition, data: fundraisePositionData } = useFundraisePosition()
-  const [navigationLinks, setNavigationLinks] = useState<NavigationLink[]>([])
-
-  useEffect(() => {
-    if (accountData?.address) {
-      getFundraisePosition(accountData.address)
-    }
-  }, [accountData?.address, getFundraisePosition])
-
-  useEffect(() => {
-    let links: NavigationLink[] = [
-      {
-        title: "OVERVIEW",
-        route: routes.Overview,
-      },
-      {
-        title: "STAKE",
-        route: routes.Stake,
-      },
-      {
-        title: "POSITIONS",
-        route: routes.Positions,
-      },
-    ]
-
-    if (fundraisePositionData) {
-      links = [
-        ...links,
-        {
-          title: "CLAIM",
-          route: routes.FundraiseClaim,
-        },
-      ]
-    }
-    setNavigationLinks(links)
-  }, [location.pathname, fundraisePositionData])
-
   return (
     <>
-      <div className={styles.app}>
-        <div className={styles.noise} />
-        <Header navigationLinks={navigationLinks} />
-        <div className={styles.contentContainer}>
-          <div className={styles.content}>
-            <Routes>
-              <Route path={routes.Stake} element={<StakingPage />} />
-              <Route path={routes.Overview} element={<OverviewPage />} />
-              <Route path={routes.Positions} element={<StakingPositionsPage />} />
-              <Route path={routes.FundraiseClaim} element={<FundraisingClaimPage />} />
-              <Route path={routes.Protocol} element={<ProtocolPage />} />
-              <Route path={routes.USForbidden} element={<USForbiddenPage />} />
-              <Route path="*" element={<Navigate replace to={routes.Stake} />} />
-            </Routes>
-          </div>
-        </div>
-        <Footer />
-      </div>
+      <Routes>
+        {/** Stakers section routes */}
+        <Route path="/*" element={<AppStakers />}>
+          <Route path={routes.Stake} element={<StakingPage />} />
+          <Route path={routes.Overview} element={<OverviewPage />} />
+          <Route path={routes.Positions} element={<StakingPositionsPage />} />
+          <Route path={routes.FundraiseClaim} element={<FundraisingClaimPage />} />
+          <Route path={routes.USForbidden} element={<USForbiddenPage />} />
+
+          <Route path="*" element={<Navigate replace to={`/${routes.Stake}`} />} />
+        </Route>
+
+        {/** Protocols section routes */}
+        <Route path={`${routes.Protocols}/*`} element={<AppProtocols />}>
+          <Route path={protocolsRoutes.Balance} element={<ProtocolPage />} />
+
+          <Route path="*" element={<Navigate replace to={protocolsRoutes.Balance} />} />
+        </Route>
+
+        <Route path="*" element={<Navigate replace to="/" />} />
+      </Routes>
+
       <MobileBlock />
     </>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,9 @@ import { OverviewPage } from "./pages/Overview"
 import { ProtocolPage } from "./pages/Protocol"
 import AppStakers from "./AppStakers"
 import AppProtocols from "./AppProtocols"
+import AppInternal from "./AppInternal"
 
-import { routes, protocolsRoutes } from "./utils/routes"
+import { routes, protocolsRoutes, internalRoutes } from "./utils/routes"
 import MobileBlock from "./components/MobileBlock/MobileBlock"
 import { InternalOverviewPage } from "./pages/InternalOverview/InternalOverview"
 
@@ -36,7 +37,12 @@ function App() {
           <Route path="*" element={<Navigate replace to={protocolsRoutes.Balance} />} />
         </Route>
 
-        <Route path={routes.InternalOverview} element={<InternalOverviewPage />} />
+        {/** Internal section routes */}
+        <Route path={`${routes.Internal}/*`} element={<AppInternal />}>
+          <Route path={internalRoutes.InternalOverview} element={<InternalOverviewPage />} />
+
+          <Route path="*" element={<Navigate replace to={internalRoutes.InternalOverview} />} />
+        </Route>
 
         <Route path="*" element={<Navigate replace to="/" />} />
       </Routes>

--- a/src/AppInternal.tsx
+++ b/src/AppInternal.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import { Outlet } from "react-router-dom"
+import { Footer } from "./components/Footer"
+import { Header, NavigationLink } from "./components/Header"
+
+import styles from "./App.module.scss"
+import { internalRoutes } from "./utils/routes"
+
+const AppInternal = () => {
+  const navigationLinks: NavigationLink[] = [
+    {
+      title: "OVERVIEW",
+      route: internalRoutes.InternalOverview,
+    },
+  ]
+
+  return (
+    <div className={styles.app}>
+      <div className={styles.noise} />
+      <Header navigationLinks={navigationLinks} />
+      <div className={styles.contentContainer}>
+        <div className={styles.content}>
+          <Outlet />
+        </div>
+      </div>
+      <Footer />
+    </div>
+  )
+}
+
+export default AppInternal

--- a/src/AppProtocols.tsx
+++ b/src/AppProtocols.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import { Outlet } from "react-router-dom"
+import { Footer } from "./components/Footer"
+import { Header, NavigationLink } from "./components/Header"
+
+import styles from "./App.module.scss"
+import { protocolsRoutes } from "./utils/routes"
+
+const AppProtocols = () => {
+  const navigationLinks: NavigationLink[] = [
+    {
+      title: "BALANCE",
+      route: protocolsRoutes.Balance,
+    },
+  ]
+
+  return (
+    <div className={styles.app}>
+      <div className={styles.noise} />
+      <Header navigationLinks={navigationLinks} />
+      <div className={styles.contentContainer}>
+        <div className={styles.content}>
+          <Outlet />
+        </div>
+      </div>
+      <Footer />
+    </div>
+  )
+}
+
+export default AppProtocols

--- a/src/AppStakers.tsx
+++ b/src/AppStakers.tsx
@@ -31,6 +31,11 @@ const AppStakers = () => {
       title: "POSITIONS",
       route: routes.Positions,
     },
+    {
+      title: "PROTOCOLS",
+      route: routes.Protocols,
+      external: true,
+    },
   ]
 
   if (fundraisePositionData) {

--- a/src/AppStakers.tsx
+++ b/src/AppStakers.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect } from "react"
+import { Outlet } from "react-router-dom"
+import { useAccount } from "wagmi"
+import { Footer } from "./components/Footer"
+import { Header, NavigationLink } from "./components/Header"
+import { useFundraisePosition } from "./hooks/api/useFundraisePosition"
+import { routes } from "./utils/routes"
+
+import styles from "./App.module.scss"
+
+const AppStakers = () => {
+  const [{ data: accountData }] = useAccount()
+  const { getFundraisePosition, data: fundraisePositionData } = useFundraisePosition()
+
+  useEffect(() => {
+    if (accountData?.address) {
+      getFundraisePosition(accountData.address)
+    }
+  }, [accountData?.address, getFundraisePosition])
+
+  const navigationLinks: NavigationLink[] = [
+    {
+      title: "OVERVIEW",
+      route: routes.Overview,
+    },
+    {
+      title: "STAKE",
+      route: routes.Stake,
+    },
+    {
+      title: "POSITIONS",
+      route: routes.Positions,
+    },
+  ]
+
+  if (fundraisePositionData) {
+    navigationLinks.push({
+      title: "CLAIM",
+      route: routes.FundraiseClaim,
+    })
+  }
+
+  return (
+    <div className={styles.app}>
+      <div className={styles.noise} />
+      <Header navigationLinks={navigationLinks} />
+      <div className={styles.contentContainer}>
+        <div className={styles.content}>
+          <Outlet />
+        </div>
+      </div>
+      <Footer />
+    </div>
+  )
+}
+
+export default AppStakers

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -23,6 +23,12 @@
       text-transform: uppercase;
       font-weight: 700;
       color: white;
+      display: flex;
+      align-items: baseline;
+
+      & > *:last-child {
+        margin-left: 0.5rem;
+      }
     }
   }
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -8,6 +8,7 @@ import { ReactComponent as Logotype } from "../../assets/icons/logotype.svg"
 
 import styles from "./Header.module.scss"
 import { Row } from "../Layout"
+import { Link } from "react-router-dom"
 
 export type NavigationLink = {
   title: string
@@ -30,7 +31,9 @@ export const Header: React.FC<HeaderProps> = ({ navigationLinks = [], logoOnly =
   return (
     <div className={styles.container}>
       <div className={styles.leftArea}>
-        <Logotype height={60} width={60} />
+        <Link to="/">
+          <Logotype height={60} width={60} />
+        </Link>
       </div>
       {!logoOnly && (
         <div className={styles.centerArea}>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-
+import { FaExternalLinkAlt } from "react-icons/fa"
 import ConnectButton from "../ConnectButton/ConnectButton"
 import CustomLink from "../CustomLink/CustomLink"
 import { Route } from "../../utils/routes"
@@ -13,6 +13,7 @@ import { Link } from "react-router-dom"
 export type NavigationLink = {
   title: string
   route: Route
+  external?: boolean
 }
 
 type HeaderProps = {
@@ -37,10 +38,11 @@ export const Header: React.FC<HeaderProps> = ({ navigationLinks = [], logoOnly =
       </div>
       {!logoOnly && (
         <div className={styles.centerArea}>
-          <Row alignment="center">
+          <Row alignment={["center", "center"]}>
             {navigationLinks.map((navLink) => (
               <CustomLink key={navLink.route} to={navLink.route}>
                 {navLink.title}
+                {navLink.external && <FaExternalLinkAlt />}
               </CustomLink>
             ))}
           </Row>

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -3,12 +3,16 @@ export const routes = {
   Positions: "positions",
   Fundraise: "fundraise",
   FundraiseClaim: "fundraiseclaim",
-  Protocol: "protocol",
+  Protocols: "protocols",
   Overview: "overview",
   USForbidden: "us",
 } as const
 
-type R = typeof routes
+export const protocolsRoutes = {
+  Balance: "balance",
+} as const
+
+type R = typeof routes & typeof protocolsRoutes
 
 type ValueOf<T> = T[keyof T]
 

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -4,8 +4,8 @@ export const routes = {
   Fundraise: "fundraise",
   FundraiseClaim: "fundraiseclaim",
   Protocols: "protocols",
+  Internal: "internal",
   Overview: "overview",
-  InternalOverview: "internal",
   USForbidden: "us",
 } as const
 
@@ -13,7 +13,11 @@ export const protocolsRoutes = {
   Balance: "balance",
 } as const
 
-type R = typeof routes & typeof protocolsRoutes
+export const internalRoutes = {
+  InternalOverview: "overview",
+} as const
+
+type R = typeof routes & typeof protocolsRoutes & typeof internalRoutes
 
 type ValueOf<T> = T[keyof T]
 


### PR DESCRIPTION
## Refactor `App.tsx`

`App` component was growing in size and complexity, mainly due to the navigation links logic (what to display given certain conditions like current path or data availability from the indexer).
This won't get better with time. Most likely we'll be adding more buttons or logic to the navigation header.

The idea behind this PR is to make `App` solely responsible of routes definition, and little else (things lik

So I created 2 new components `AppProtocols` and `AppStakers`. Each of these would take care of the logic around the navigation links on their own section.

`App` will define the routes to decide which to render.

I think this not only adds more separation of concerns, but it's also more declarative.