### PR TITLE
Show SHER rewards after the APY

### DIFF
--- a/src/pages/Staking/Staking.tsx
+++ b/src/pages/Staking/Staking.tsx
@@ -47,6 +47,7 @@ export const StakingPage: React.FC = () => {
   const [stakingPeriod, setStakingPeriod] = React.useState<number>(STAKING_PERIOD_OPTIONS[0].value)
   const [sherRewards, setSherRewards] = React.useState<BigNumber>()
   const [isLoadingRewards, setIsLoadingRewards] = React.useState(false)
+  const [sherRewardsBasis, setSherRewardsBasis] = React.useState<BigNumber>()
   const { getStakingPositions, data: stakePositionsData } = useStakingPositions()
 
   const { tvl, address, stake, refreshTvl } = useSherlock()
@@ -108,6 +109,24 @@ export const StakingPage: React.FC = () => {
     getStakingPositions(accountData?.address ?? undefined)
   }, [getStakingPositions, accountData?.address])
 
+  /**
+   * Fetch SHER rewards for 1 USDC
+   */
+  React.useEffect(() => {
+    async function fetchSherRewards() {
+      if (!tvl) {
+        return
+      }
+
+      const sher = await computeRewards(tvl, ethers.utils.parseUnits("1", 6), PERIODS_IN_SECONDS.SIX_MONTHS)
+      if (sher) {
+        setSherRewardsBasis(sher)
+      }
+    }
+
+    fetchSherRewards()
+  }, [tvl, computeRewards])
+
   return (
     <Box>
       <LoadingContainer loading={isLoadingRewards}>
@@ -133,6 +152,18 @@ export const StakingPage: React.FC = () => {
               <Column>
                 <Text strong variant="mono">
                   {formatAmount(stakePositionsData?.usdcAPY)}%
+                </Text>
+              </Column>
+            </Row>
+          )}
+          {sherRewardsBasis && (
+            <Row alignment="space-between">
+              <Column>
+                <Text>Reward per 1 USDC</Text>
+              </Column>
+              <Column>
+                <Text strong variant="mono">
+                  {formatAmount(formatSHER(sherRewardsBasis))} SHER
                 </Text>
               </Column>
             </Row>


### PR DESCRIPTION
<img width="512" alt="Screenshot 2022-07-07 at 00 52 15" src="https://user-images.githubusercontent.com/1048185/177649800-a0814704-036f-4ea3-ae51-cd3b3303b36b.png">

Always show the SHER rewards per each USDC staked, even before inputting an amount.
The reward is computed by calling `calcReward` function on the `SherDistManager` contract with 1 USDC.