### PR TITLE
fix: internal chart

### DIFF
--- a/src/components/Chart/Tooltip.tsx
+++ b/src/components/Chart/Tooltip.tsx
@@ -6,13 +6,13 @@ import { Text } from "../Text"
 
 import styles from "./Tooltip.module.scss"
 
-export const Tooltip: React.FC<TooltipProps<number, string>> = ({ label, payload, formatter }) => {
+export const Tooltip: React.FC<TooltipProps<number, string>> = ({ label, payload, formatter, labelFormatter }) => {
   return (
     <div className={styles.tooltip}>
       <Column spacing="s">
         <Row>
           <Text strong size="tiny">
-            {label}
+            {labelFormatter ? labelFormatter(label, payload!) : label}
           </Text>
         </Row>
         {payload?.map((p, index) => {

--- a/src/pages/InternalOverview/InternalOverview.module.scss
+++ b/src/pages/InternalOverview/InternalOverview.module.scss
@@ -1,3 +1,4 @@
 .container {
   display: flex;
+  width: 100%;
 }


### PR DESCRIPTION
- Allow the `CustomTooltip` to use the custom `labelFormatter` prop
- Let the internal chart use the entire width of the page