### PR TITLE
fix: tooltip on chart load

### DIFF
--- a/src/components/Chart/Tooltip.tsx
+++ b/src/components/Chart/Tooltip.tsx
@@ -7,12 +7,17 @@ import { Text } from "../Text"
 import styles from "./Tooltip.module.scss"
 
 export const Tooltip: React.FC<TooltipProps<number, string>> = ({ label, payload, formatter, labelFormatter }) => {
+  let finalLabel = label
+  if (!!label && labelFormatter && payload !== undefined && payload !== null) {
+    finalLabel = labelFormatter(label, payload)
+  }
+
   return (
     <div className={styles.tooltip}>
       <Column spacing="s">
         <Row>
           <Text strong size="tiny">
-            {labelFormatter ? labelFormatter(label, payload!) : label}
+            {finalLabel}
           </Text>
         </Row>
         {payload?.map((p, index) => {


### PR DESCRIPTION
- Fix an issue when `label` would be null on a slow chart startup

Copied the same validation from `recharts/src/component/DefaultTooltipContent.tsx` which is used to render the content in the default `Tooltip` component