### PR TITLE
Fundraise claim

### DIFF
--- a/src/hooks/api/useFundraisePosition.tsx
+++ b/src/hooks/api/useFundraisePosition.tsx
@@ -2,13 +2,15 @@ import React, { PropsWithChildren, useCallback, useState } from "react"
 import { BigNumber, ethers } from "ethers"
 import axios from "./axios"
 import { getFundraisePosition as getFundraisePositionUrl } from "./urls"
+import { DateTime } from "luxon"
 
 type FundraisePosition = {
-  claimableAt: Date
+  claimableAt: DateTime
   contribution: BigNumber
   reward: BigNumber
   stake: BigNumber
   owner: string
+  claimedAt: DateTime | null
 }
 
 type GetFundraisePositionResponseData =
@@ -19,6 +21,7 @@ type GetFundraisePositionResponseData =
         id: string
         reward: string
         stake: string
+        claimed_at: number | null
       }
       ok: true
     }
@@ -32,10 +35,11 @@ const parseResponse = (response: GetFundraisePositionResponseData): FundraisePos
 
   return {
     owner: response.data.id,
-    claimableAt: new Date(response.data.claimable_at * 1000),
+    claimableAt: DateTime.fromSeconds(response.data.claimable_at),
     contribution: BigNumber.from(response.data.contribution),
     reward: BigNumber.from(response.data.reward),
     stake: BigNumber.from(response.data.stake),
+    claimedAt: response.data.claimed_at ? DateTime.fromSeconds(response.data.claimed_at) : null,
   }
 }
 

--- a/src/hooks/useSherClaimContract.ts
+++ b/src/hooks/useSherClaimContract.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from "react"
 import { useContract, useProvider, useSigner } from "wagmi"
 import SherClaimInterface from "../abi/SherClaim.json"
 import { SherClaim } from "../contracts/SherClaim"
-import useWaitTx from "./useWaitTx"
 import { DateTime } from "luxon"
 import config from "../config"
 
@@ -25,7 +24,6 @@ export const useSherClaimContract = () => {
     contractInterface: SherClaimInterface.abi,
     signerOrProvider: signerData || provider,
   })
-  const { waitForTx } = useWaitTx()
 
   /**
    * Fetch date at which tokens become available to claim.
@@ -53,9 +51,8 @@ export const useSherClaimContract = () => {
    * Claim SHER tokens.
    */
   const claim = useCallback(async () => {
-    const txReceipt = await waitForTx(async () => await contract.claim())
-    return txReceipt
-  }, [contract, waitForTx])
+    return contract.claim()
+  }, [contract])
 
   /**
    * Fetch the amount of SHER an address can claim once they become claimable


### PR DESCRIPTION
- Parsed the `claimed_at` field of the fundraising position in order to disable claiming if the position was already claimed, and to show the date when it was claimed
- Refresh the page after the claim event is processed in the indexer (using `waitForBlock`)