### PR TITLE
Contests order

### DIFF
--- a/src/pages/Contests/ActiveContests.tsx
+++ b/src/pages/Contests/ActiveContests.tsx
@@ -16,7 +16,10 @@ type Props = {
 }
 
 export const ActiveContests: React.FC<Props> = ({ contests, onContestClick }) => {
-  const activeContests = useMemo(() => contests?.filter((c) => c.status === "RUNNING"), [contests])
+  const activeContests = useMemo(
+    () => contests?.filter((c) => c.status === "RUNNING").sort((a, b) => a.endDate - b.endDate),
+    [contests]
+  )
 
   if (!activeContests || activeContests.length === 0) return null
 

--- a/src/pages/Contests/FinishedContests.tsx
+++ b/src/pages/Contests/FinishedContests.tsx
@@ -18,7 +18,8 @@ type Props = {
 
 export const FinishedContests: React.FC<Props> = ({ contests, onContestClick }) => {
   const finishedContests = useMemo(
-    () => contests?.filter((c) => c.status === "FINISHED" || c.status === "JUDGING"),
+    () =>
+      contests?.filter((c) => c.status === "FINISHED" || c.status === "JUDGING").sort((a, b) => a.endDate - b.endDate),
     [contests]
   )
 

--- a/src/pages/Contests/FinishedContests.tsx
+++ b/src/pages/Contests/FinishedContests.tsx
@@ -19,7 +19,7 @@ type Props = {
 export const FinishedContests: React.FC<Props> = ({ contests, onContestClick }) => {
   const finishedContests = useMemo(
     () =>
-      contests?.filter((c) => c.status === "FINISHED" || c.status === "JUDGING").sort((a, b) => a.endDate - b.endDate),
+      contests?.filter((c) => c.status === "FINISHED" || c.status === "JUDGING").sort((a, b) => b.endDate - a.endDate),
     [contests]
   )
 

--- a/src/pages/Contests/UpcomingContests.tsx
+++ b/src/pages/Contests/UpcomingContests.tsx
@@ -16,7 +16,10 @@ type Props = {
 }
 
 export const UpcomingContests: React.FC<Props> = ({ contests, onContestClick }) => {
-  const upcomingContests = useMemo(() => contests?.filter((c) => c.status === "CREATED"), [contests])
+  const upcomingContests = useMemo(
+    () => contests?.filter((c) => c.status === "CREATED").sort((a, b) => a.startDate - b.startDate),
+    [contests]
+  )
 
   if (!upcomingContests || upcomingContests.length === 0) return null
 


### PR DESCRIPTION
Contests are ordered as follows:
- Active contests by their end date, ascending (earliest ending first)
- Upcoming contests by their start date, ascending (earliest starting first)
- Finished contests by their end date, descending (latest ended first)