### PR TITLE
fix: use luxon Interval to calculate audit length

### DIFF
--- a/src/AppProtocolDashboard.tsx
+++ b/src/AppProtocolDashboard.tsx
@@ -117,7 +117,7 @@ const AppProtocolDashboard = () => {
                         <Text strong>Audit Length</Text>
                       </Td>
                       <Td>
-                        <Text alignment="right">{`${length} days`}</Text>
+                        <Text alignment="right">{`${+length.toFixed(2)} days`}</Text>
                       </Td>
                     </Tr>
                     <Tr>

--- a/src/AppProtocolDashboard.tsx
+++ b/src/AppProtocolDashboard.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from "react"
 import { Outlet, useParams } from "react-router-dom"
 import { FaCheck, FaGithub } from "react-icons/fa"
 import { commify } from "ethers/lib/utils.js"
-import { DateTime } from "luxon"
+import { DateTime, Interval } from "luxon"
 
 import { Footer } from "./components/Footer"
 import { Header, NavigationLink } from "./components/Header"
@@ -81,7 +81,7 @@ const AppProtocolDashboard = () => {
   const { contest, payments } = protocolDashboard
   const startDate = DateTime.fromSeconds(contest.startDate)
   const endDate = DateTime.fromSeconds(contest.endDate)
-  const length = Math.floor(endDate.diff(startDate, "days").days)
+  const length = Interval.fromDateTimes(startDate, endDate).length("days")
   const fullyPaid = payments.totalPaid >= payments.totalAmount
 
   return (


### PR DESCRIPTION
Update audit length calculation method to use `Interval` instead of `Duration`s.

Based on this: https://moment.github.io/luxon/#/math?id=losing-information