### PR TITLE
fix: discord 0 discriminator

### DIFF
--- a/src/components/AuditorForm/AuditorForm.tsx
+++ b/src/components/AuditorForm/AuditorForm.tsx
@@ -162,6 +162,11 @@ export const AuditorForm: React.FC<Props> = ({
       isDirty,
     ]
   )
+
+  const validatedDiscordHandle = discordValidation
+    ? discordValidation.handle + (discordValidation.discriminator !== "0" ? `#${discordValidation.discriminator}` : "")
+    : ""
+
   return (
     <Column spacing="l">
       <Row>
@@ -213,7 +218,9 @@ export const AuditorForm: React.FC<Props> = ({
                 <>
                   <FaDiscord />
                   <Text>{discordValidation.handle}</Text>
-                  <Text variant="secondary">{`#${discordValidation.discriminator}`}</Text>
+                  {discordValidation?.discriminator !== "0" && (
+                    <Text variant="secondary">{`#${discordValidation.discriminator}`}</Text>
+                  )}
                 </>
               )}
               {!isValidatingDiscordHandle && !discordValidation && (
@@ -264,7 +271,7 @@ export const AuditorForm: React.FC<Props> = ({
             onSubmit({
               handle,
               githubHandle,
-              discordHandle: discordValidation ? `${discordValidation.handle}#${discordValidation.discriminator}` : "",
+              discordHandle: validatedDiscordHandle,
               telegramHandle,
               twitterHandle,
             })

--- a/src/hooks/api/auditors/useValidateDiscordHandle.ts
+++ b/src/hooks/api/auditors/useValidateDiscordHandle.ts
@@ -4,13 +4,13 @@ import { validateDiscordHandle as validateDiscordHandleUrl } from "../urls"
 
 type ValidateDiscordHandleResponse = {
   handle: string
-  discriminator: number
+  discriminator: string
   user_id: number
 }
 
 type DiscordHandleValidation = {
   handle: string
-  discriminator: number
+  discriminator: string
   userID: number
 }
 


### PR DESCRIPTION
During the transition period to Discord usernames, users will have the discriminator "0". We need to hide the discriminator in this case, and only show the username.

This only concerns the `discord_handle` user field, which is only used for the profile. Internally, the backend uses the user ID, so nothing else needs to be changed.